### PR TITLE
Shack card on massif view

### DIFF
--- a/src/components/ShackListItem.vue
+++ b/src/components/ShackListItem.vue
@@ -37,7 +37,7 @@
         <v-card
           flat 
           height="200px"
-          @click="goToShack(shack)"
+          @click.native="goToShack(shack)"
           class="pointer">
           <v-card-text>
             <div class="shack-type mb-1">{{ shack.type }}</div>

--- a/src/components/ShackListItem.vue
+++ b/src/components/ShackListItem.vue
@@ -34,8 +34,7 @@
 
       <!-- info -->
       <v-col cols="12" sm="7" class="px-0 pb-0">
-        <v-card flat>
-          <v-card-text>
+        <v-card-text flat @click="goToShack(shack)">
           <div class="shack-type mb-1">{{ shack.type }}</div>
           <div class="shack-name">{{ shack.name }}</div>
           <div class="shack-divider"></div>
@@ -74,13 +73,6 @@
             </template>
           </v-row>
         </v-card-text>
-        <v-card-actions>
-          <v-btn
-            text
-            @click="goToShack(shack)"
-          >détails</v-btn>
-        </v-card-actions>
-      </v-card>
 
       </v-col>
     </v-row>

--- a/src/components/ShackListItem.vue
+++ b/src/components/ShackListItem.vue
@@ -34,50 +34,51 @@
 
       <!-- info -->
       <v-col cols="12" sm="7" class="px-0 pb-0">
-        <v-card-text
+        <v-card
           flat 
+          height="200px"
           @click="goToShack(shack)"
-          class="pointer"
-          >
-          <div class="shack-type mb-1">{{ shack.type }}</div>
-          <div class="shack-name">{{ shack.name }}</div>
-          <div class="shack-divider"></div>
-          <v-row>
-            <!-- altitude -->
-            <v-col cols="5">
-              <div class="flex-container">
-                <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/mountain.png')"></v-img></div>
-                <div class="flex-child">Altitude : {{ shack.altitude }}m</div>
-              </div>
-            </v-col>
-            <!-- beds -->
-            <v-col cols="7">
-              <div class="flex-container">
-                <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/bed.png')"></v-img></div>
-                <div class="flex-child">Capacité : {{ shack.beds }} personnes</div>
-              </div>
-            </v-col>
-            <!-- stove -->
-            <template v-if="shack.stove">
+          class="pointer">
+          <v-card-text>
+            <div class="shack-type mb-1">{{ shack.type }}</div>
+            <div class="shack-name">{{ shack.name }}</div>
+            <div class="shack-divider"></div>
+            <v-row>
+              <!-- altitude -->
               <v-col cols="5">
                 <div class="flex-container">
-                  <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/stove.png')"></v-img></div>
-                  <div class="flex-child">Poêle</div>
+                  <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/mountain.png')"></v-img></div>
+                  <div class="flex-child">Altitude : {{ shack.altitude }}m</div>
                 </div>
               </v-col>
-            </template>
-            <!-- water -->
-            <template v-if="shack.water">
+              <!-- beds -->
               <v-col cols="7">
                 <div class="flex-container">
-                  <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/water.png')"></v-img></div>
-                  <div class="flex-child">Source</div>
+                  <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/bed.png')"></v-img></div>
+                  <div class="flex-child">Capacité : {{ shack.beds }} personnes</div>
                 </div>
               </v-col>
-            </template>
-          </v-row>
-        </v-card-text>
-
+              <!-- stove -->
+              <template v-if="shack.stove">
+                <v-col cols="5">
+                  <div class="flex-container">
+                    <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/stove.png')"></v-img></div>
+                    <div class="flex-child">Poêle</div>
+                  </div>
+                </v-col>
+              </template>
+              <!-- water -->
+              <template v-if="shack.water">
+                <v-col cols="7">
+                  <div class="flex-container">
+                    <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/water.png')"></v-img></div>
+                    <div class="flex-child">Source</div>
+                  </div>
+                </v-col>
+              </template>
+            </v-row>
+          </v-card-text>
+        </v-card>
       </v-col>
     </v-row>
   </v-container>

--- a/src/components/ShackListItem.vue
+++ b/src/components/ShackListItem.vue
@@ -12,6 +12,7 @@
             height="200px"
             class="shack-img"
             :key="shack.key"
+            :lazy-src="getPreloadImage(images, 0, { height: 200 })"
             :src="getImage(images, 0, { height: 200 })"
           >
           </v-img>
@@ -25,6 +26,7 @@
             <v-carousel-item
               v-for="(image, i) in images"
               :key="i"
+              :lazy-src="getPreloadImage(images, i, { height: 200 })"
               :src="getImage(images, i, { height: 200 })"
             >
             </v-carousel-item>

--- a/src/components/ShackListItem.vue
+++ b/src/components/ShackListItem.vue
@@ -55,19 +55,23 @@
               </div>
             </v-col>
             <!-- stove -->
-            <v-col cols="5">
-              <div class="flex-container">
-                <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/stove.png')"></v-img></div>
-                <div class="flex-child">Poêle : {{ shack.stove ? 'oui' : 'non' }}</div>
-              </div>
-            </v-col>
+            <template v-if="shack.stove">
+              <v-col cols="5">
+                <div class="flex-container">
+                  <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/stove.png')"></v-img></div>
+                  <div class="flex-child">Poêle</div>
+                </div>
+              </v-col>
+            </template>
             <!-- water -->
-            <v-col cols="7">
-              <div class="flex-container">
-                <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/water.png')"></v-img></div>
-                <div class="flex-child">Source : {{ shack.water ? 'oui' : 'non' }}</div>
-              </div>
-            </v-col>
+            <template v-if="shack.water">
+              <v-col cols="7">
+                <div class="flex-container">
+                  <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/water.png')"></v-img></div>
+                  <div class="flex-child">Source</div>
+                </div>
+              </v-col>
+            </template>
           </v-row>
         </v-card-text>
         <v-card-actions>

--- a/src/components/ShackListItem.vue
+++ b/src/components/ShackListItem.vue
@@ -59,23 +59,19 @@
                 </div>
               </v-col>
               <!-- stove -->
-              <template v-if="shack.stove">
-                <v-col cols="5">
-                  <div class="flex-container">
-                    <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/stove.png')"></v-img></div>
-                    <div class="flex-child">Poêle</div>
-                  </div>
-                </v-col>
-              </template>
+              <v-col cols="5">
+                <div class="flex-container">
+                  <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/stove.png')"></v-img></div>
+                  <div :class="shack.stove ? 'flex-child' : 'flex-child-strikethrough'">Poêle</div>
+                </div>
+              </v-col>
               <!-- water -->
-              <template v-if="shack.water">
-                <v-col cols="7">
-                  <div class="flex-container">
-                    <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/water.png')"></v-img></div>
-                    <div class="flex-child">Source</div>
-                  </div>
-                </v-col>
-              </template>
+              <v-col cols="7">
+                <div class="flex-container">
+                  <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/water.png')"></v-img></div>
+                  <div :class="shack.water ? 'flex-child' : 'flex-child-strikethrough'">Source</div>
+                </div>
+              </v-col>
             </v-row>
           </v-card-text>
         </v-card>
@@ -144,6 +140,11 @@ export default {
 
 .flex-child {
   flex: 1;
+}
+
+.flex-child-strikethrough {
+  flex: 1;
+  text-decoration: line-through;
 }
 
 .pointer {

--- a/src/components/ShackListItem.vue
+++ b/src/components/ShackListItem.vue
@@ -34,7 +34,11 @@
 
       <!-- info -->
       <v-col cols="12" sm="7" class="px-0 pb-0">
-        <v-card-text flat @click="goToShack(shack)">
+        <v-card-text
+          flat 
+          @click="goToShack(shack)"
+          class="pointer"
+          >
           <div class="shack-type mb-1">{{ shack.type }}</div>
           <div class="shack-name">{{ shack.name }}</div>
           <div class="shack-divider"></div>
@@ -139,6 +143,10 @@ export default {
 
 .flex-child {
   flex: 1;
+}
+
+.pointer {
+  cursor: pointer;
 }
 
 </style>

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -37,23 +37,19 @@
       </v-row>
       <v-row>
         <!-- stove -->
-        <template v-if="cabane.stove">
-          <v-col cols="6">
-            <div class="flex-container">
-              <div class="flex-child"><v-img height="25px" width="25px" :src="require('@/assets/icons/stove.png')"></v-img></div>
-              <div class="flex-child">Poêle</div>
-            </div>
-          </v-col>
-        </template>
+        <v-col cols="6">
+          <div class="flex-container">
+            <div class="flex-child"><v-img height="25px" width="25px" :src="require('@/assets/icons/stove.png')"></v-img></div>
+            <div :class="cabane.stove ? 'flex-child' : 'flex-child-strikethrough'">Poêle</div>
+          </div>
+        </v-col>
         <!-- water -->
-        <template v-if="cabane.water">
-          <v-col cols="6">
-            <div class="flex-container">
-              <div class="flex-child"><v-img height="25px" width="25px" :src="require('@/assets/icons/water.png')"></v-img></div>
-              <div class="flex-child">Source</div>
-            </div>
-          </v-col>
-        </template>
+        <v-col cols="6">
+          <div class="flex-container">
+            <div class="flex-child"><v-img height="25px" width="25px" :src="require('@/assets/icons/water.png')"></v-img></div>
+            <div :class="cabane.water ? 'flex-child' : 'flex-child-strikethrough'">Source</div>
+          </div>
+        </v-col>
       </v-row>
     </v-card-text>
   </v-card>
@@ -96,6 +92,11 @@ export default {
 .flex-child {
   flex: 1;
 } 
+
+.flex-child-strikethrough {
+  flex: 2;
+  text-decoration: line-through;
+}
 
 .flex-child:last-child {
   margin-right: 25px;

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -32,19 +32,23 @@
       </v-row>
       <v-row>
         <!-- stove -->
-        <v-col cols="6">
-          <div class="flex-container">
-            <div class="flex-child"><v-img height="25px" width="25px" :src="require('@/assets/icons/stove.png')"></v-img></div>
-            <div class="flex-child">{{ cabane.stove ? 'oui' : 'non' }}</div>
-          </div>
-        </v-col>
+        <template v-if="cabane.stove">
+          <v-col cols="6">
+            <div class="flex-container">
+              <div class="flex-child"><v-img height="25px" width="25px" :src="require('@/assets/icons/stove.png')"></v-img></div>
+              <div class="flex-child">Poêle</div>
+            </div>
+          </v-col>
+        </template>
         <!-- water -->
-        <v-col cols="6">
-          <div class="flex-container">
-            <div class="flex-child"><v-img height="25px" width="25px" :src="require('@/assets/icons/water.png')"></v-img></div>
-            <div class="flex-child">{{ cabane.water ? 'oui' : 'non' }}</div>
-          </div>
-        </v-col>
+        <template v-if="cabane.water">
+          <v-col cols="6">
+            <div class="flex-container">
+              <div class="flex-child"><v-img height="25px" width="25px" :src="require('@/assets/icons/water.png')"></v-img></div>
+              <div class="flex-child">Source</div>
+            </div>
+          </v-col>
+        </template>
       </v-row>
     </v-card-text>
     <v-card-actions>

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -8,7 +8,7 @@
     >
     </v-img>
 
-    <v-card-text class="text--primary pb-0">
+    <v-card-text @click="goToShack(cabane)" class="text--primary pb-4">
       <v-row>
         <v-col cols="12" class="card-title">
           {{ cabane.name }}
@@ -51,9 +51,6 @@
         </template>
       </v-row>
     </v-card-text>
-    <v-card-actions>
-      <v-btn text @click="goToShack(cabane)">détails</v-btn>
-    </v-card-actions>
   </v-card>
 </template>
 
@@ -78,10 +75,6 @@ export default {
 <style scoped>
 .v-card {
   border-radius: 12px !important;
-}
-
-.v-btn {
-  font-weight: inherit;
 }
 
 .card-title {

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-card class="mx-auto" max-width="250" min-width="250" flat>
+  <v-card
+    class="pointer" 
+    max-width="250"
+    min-width="250" 
+    flat
+    @click.native="goToShack(cabane)">
     <v-img
       v-if="images.length !== 0"
       class="white--text align-end"
@@ -8,8 +13,7 @@
     >
     </v-img>
 
-    <v-card-text 
-      @click="goToShack(cabane)" class="pointer">
+    <v-card-text>
       <v-row>
         <v-col cols="12" class="card-title">
           {{ cabane.name }}

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -8,7 +8,8 @@
     >
     </v-img>
 
-    <v-card-text @click="goToShack(cabane)" class="text--primary pb-4">
+    <v-card-text 
+      @click="goToShack(cabane)" class="pointer">
       <v-row>
         <v-col cols="12" class="card-title">
           {{ cabane.name }}
@@ -94,5 +95,9 @@ export default {
 
 .flex-child:last-child {
   margin-right: 25px;
-} 
+}
+
+.pointer {
+  cursor: pointer;
+}
 </style>

--- a/src/data/massifs.json
+++ b/src/data/massifs.json
@@ -123,12 +123,12 @@
     }
   },
   {
-    "name": "Pyrénées centrales",
-    "key": "pyrenees-centrales",
-    "connector": "des",
+    "name": "Bigorre",
+    "key": "bigorre",
+    "connector": "de",
     "location": {
       "region": "Occitanie",
-      "department": "Hautes-Pyrénées, Ariège, Haute-Garonne"
+      "department": "Hautes-Pyrénées"
     },
     "data": {
       "sheetId": "1sHiHXqGC43HzvVGXZj2UBV-Rc7Li4kzCBYTAskBv-dA"

--- a/src/data/massifs.json
+++ b/src/data/massifs.json
@@ -121,5 +121,17 @@
     "data": {
       "sheetId": "1Z5pmYvoLjMBuSSitS3m3a94Gl2xxLQW2ll_hoaOxQko"
     }
+  },
+  {
+    "name": "Pyrénées centrales",
+    "key": "pyrenees-centrales",
+    "connector": "des",
+    "location": {
+      "region": "Occitanie",
+      "department": "Hautes-Pyrénées, Ariège, Haute-Garonne"
+    },
+    "data": {
+      "sheetId": "1sHiHXqGC43HzvVGXZj2UBV-Rc7Li4kzCBYTAskBv-dA"
+    }
   }
 ]

--- a/src/mixins/ImageMixin.js
+++ b/src/mixins/ImageMixin.js
@@ -11,11 +11,6 @@ export default {
       if (imageList[index].includes('cloudinary')) {
         return `${imageList[index].slice(0, PARAM_IDX)}h_${height * QUALITY_FACTOR},f_auto,e_blur:10000,q_1/${imageList[index].slice(PARAM_IDX)}`;
       }
-    },
-    getMetaImageUrl(imageList, index, { height }) {
-      if (imageList[index].includes('cloudinary')) {
-        return `${imageList[index].slice(0, PARAM_IDX)}h_${height * QUALITY_FACTOR},f_auto/${imageList[index].slice(PARAM_IDX)}`;
-      }
     }
   },
 };

--- a/src/mixins/ImageMixin.js
+++ b/src/mixins/ImageMixin.js
@@ -7,6 +7,11 @@ export default {
         return `${imageList[index].slice(0, PARAM_IDX)}h_${height * QUALITY_FACTOR},f_auto/${imageList[index].slice(PARAM_IDX)}`;
       }
     },
+    getPreloadImage(imageList, index, { height }) {
+      if (imageList[index].includes('cloudinary')) {
+        return `${imageList[index].slice(0, PARAM_IDX)}h_${height * QUALITY_FACTOR},f_auto,e_blur:10000,q_1/${imageList[index].slice(PARAM_IDX)}`;
+      }
+    },
     getMetaImageUrl(imageList, index, { height }) {
       if (imageList[index].includes('cloudinary')) {
         return `${imageList[index].slice(0, PARAM_IDX)}h_${height * QUALITY_FACTOR},f_auto/${imageList[index].slice(PARAM_IDX)}`;

--- a/src/mixins/ImageMixin.js
+++ b/src/mixins/ImageMixin.js
@@ -14,7 +14,7 @@ export default {
     },
     getParams(imageType) {
       if (!Object.keys(PARAMETERS).includes(imageType)) return '';
-      return PARAMETERS[imageType].joint(',');
+      return PARAMETERS[imageType].join(',');
     }
   },
 };

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -3,7 +3,7 @@
     <v-row class="section" :class="`section-height-${screenWidth < $vuetify.breakpoint.thresholds.sm ? 'mobile' : 'desktop'}`">
       <v-img
         height="100%"
-        lazy-src="R0lGODlhCQAHAPUAABIWGhUcIhghKxslMR8rOigsMjw2MEI+OSgzQi46SDw+QT1AREhLTFBOS0JMVk1PUVtZVVRZXU5bZV5kZlhlcHFrZHtyZ3dzbI2CdGNxgGh3hmt9ind+hWt+lG6FnXGHmneUtHmYvFyP0V2Q0V+R0mCT1GOV1mqb2HCg2nqm3YGDhqGfnp+82aC82qS+2aO+3KK+3YSw44Cy7IKz7YK07Z294Jy+44W38Ii48I+/85fE9KbF5a/N66DJ9KvQ9gAAACH5BAAAAAAALAAAAAAJAAcAAAY4wFgKdTKZRCKTr6fL4WbQG28Hg7lcLJYtBPJoLqtPpvPZUCIQzCPhkEwuFYXlICAgHo3CYGEABIIAOw=="
+        :lazy-src="getPreloadImage(image, 0, { height: sreenHeight })"
         :src="getImage(image, 0, { height: sreenHeight })"
       >
         <v-sheet color="transparent" class="overflow-y-auto" height="100%">
@@ -107,7 +107,10 @@
     <template v-else>
       <!-- vercors -->
       <v-card flat>
-        <v-img height="200px" :src="getImage(descriptions.vercors.image, 0, { height: 200 })"></v-img>
+        <v-img 
+          height="200px"
+          :lazy-src="getPreloadImage(descriptions.vercors.image, 0, { height: 200 })"></v-img>
+          :src="getImage(descriptions.vercors.image, 0, { height: 200 })"></v-img>
         <v-card-title>{{ descriptions.vercors.title }}</v-card-title>
         <v-card-text>{{ descriptions.vercors.description }}</v-card-text>
         <v-card-actions>
@@ -116,7 +119,10 @@
       </v-card>
       <!-- belledonne -->
       <v-card flat class="mt-8">
-        <v-img height="200px" :src="getImage(descriptions.belledonne.image, 0, { height: 200 })"></v-img>
+        <v-img 
+          height="200px"
+          :lazy-src="getPreloadImage(descriptions.belledonne.image, 0, { height: 200 })"></v-img>
+          :src="getImage(descriptions.belledonne.image, 0, { height: 200 })"></v-img>
         <v-card-title>{{ descriptions.belledonne.title }}</v-card-title>
         <v-card-text>{{ descriptions.belledonne.description }}</v-card-text>
         <v-card-actions>
@@ -125,7 +131,10 @@
       </v-card>
       <!-- chartreuse -->
       <v-card flat class="mt-8">
-        <v-img height="200px" :src="getImage(descriptions.chartreuse.image, 0, { height: 200 })"></v-img>
+        <v-img 
+          height="200px"
+          :lazy-src="getPreloadImage(descriptions.chartreuse.image, 0, { height: 200 })"></v-img>
+          :src="getImage(descriptions.chartreuse.image, 0, { height: 200 })"></v-img>
         <v-card-title>{{ descriptions.chartreuse.title }}</v-card-title>
         <v-card-text>{{ descriptions.chartreuse.description }}</v-card-text>
         <v-card-actions>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -109,7 +109,7 @@
       <v-card flat>
         <v-img 
           height="200px"
-          :lazy-src="getPreloadImage(descriptions.vercors.image, 0, { height: 200 })"></v-img>
+          :lazy-src="getPreloadImage(descriptions.vercors.image, 0, { height: 200 })"
           :src="getImage(descriptions.vercors.image, 0, { height: 200 })"></v-img>
         <v-card-title>{{ descriptions.vercors.title }}</v-card-title>
         <v-card-text>{{ descriptions.vercors.description }}</v-card-text>
@@ -121,7 +121,7 @@
       <v-card flat class="mt-8">
         <v-img 
           height="200px"
-          :lazy-src="getPreloadImage(descriptions.belledonne.image, 0, { height: 200 })"></v-img>
+          :lazy-src="getPreloadImage(descriptions.belledonne.image, 0, { height: 200 })"
           :src="getImage(descriptions.belledonne.image, 0, { height: 200 })"></v-img>
         <v-card-title>{{ descriptions.belledonne.title }}</v-card-title>
         <v-card-text>{{ descriptions.belledonne.description }}</v-card-text>
@@ -133,7 +133,7 @@
       <v-card flat class="mt-8">
         <v-img 
           height="200px"
-          :lazy-src="getPreloadImage(descriptions.chartreuse.image, 0, { height: 200 })"></v-img>
+          :lazy-src="getPreloadImage(descriptions.chartreuse.image, 0, { height: 200 })"
           :src="getImage(descriptions.chartreuse.image, 0, { height: 200 })"></v-img>
         <v-card-title>{{ descriptions.chartreuse.title }}</v-card-title>
         <v-card-text>{{ descriptions.chartreuse.description }}</v-card-text>

--- a/src/views/Massifs.vue
+++ b/src/views/Massifs.vue
@@ -208,7 +208,7 @@ export default {
     allShacks: [],
     mouseOveredCabaneKey: undefined,
     mouseOveredCabaneIndex: undefined,
-    cabanesPerPage: 20,
+    cabanesPerPage: 40,
     page: 1,
     isShowingMap: false,
   }),

--- a/src/views/Massifs.vue
+++ b/src/views/Massifs.vue
@@ -208,7 +208,7 @@ export default {
     allShacks: [],
     mouseOveredCabaneKey: undefined,
     mouseOveredCabaneIndex: undefined,
-    cabanesPerPage: 40,
+    cabanesPerPage: 20,
     page: 1,
     isShowingMap: false,
   }),

--- a/src/views/Shacks.vue
+++ b/src/views/Shacks.vue
@@ -38,9 +38,6 @@
               :height="imageHeight"
               hide-delimiters
               show-arrows-on-hover
-              cycle
-              interval='4000'
-              progress
             >
               <v-carousel-item
                 v-for="(image, i) in images"

--- a/src/views/Shacks.vue
+++ b/src/views/Shacks.vue
@@ -94,10 +94,10 @@
                   <div class="flex-container">
                     <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/phone.png')"></v-img></div>
                     <div class="flex-child">
-                      <a :href="`tel: ${shack.phones[0]}`"> {{ shack.phones[0] }}</a>
+                      <a :href="`tel:${shack.phones[0]}`"> {{ shack.phones[0] }}</a>
                       <template v-if="shack.phones.length > 1">
                         <a> / </a>
-                        <a :href="`tel: ${shack.phones[1]}`"> {{ shack.phones[1] }}</a>
+                        <a :href="`tel:${shack.phones[1]}`"> {{ shack.phones[1] }}</a>
                       </template>
                     </div>
                   </div>
@@ -108,7 +108,7 @@
                 <v-col cols="12" sm="7">
                   <div class="flex-container">
                     <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/email.png')"></v-img></div>
-                    <a class="flex-child-breakable" :href="`mailto: ${shack.email}`">{{ shack.email }}</a>
+                    <a class="flex-child-breakable" :href="`mailto:${shack.email}`">{{ shack.email }}</a>
                   </div>
                 </v-col>
               </template>

--- a/src/views/Shacks.vue
+++ b/src/views/Shacks.vue
@@ -94,10 +94,10 @@
                   <div class="flex-container">
                     <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/phone.png')"></v-img></div>
                     <div class="flex-child">
-                      <a :href="'tel:'+shack.phones[0]"> {{ shack.phones[0] }}</a>
+                      <a :href="`tel: ${shack.phones[0]}`"> {{ shack.phones[0] }}</a>
                       <template v-if="shack.phones.length > 1">
                         <a> / </a>
-                        <a :href="'tel:'+shack.phones[1]"> {{ shack.phones[1] }}</a>
+                        <a :href="`tel: ${shack.phones[1]}`"> {{ shack.phones[1] }}</a>
                       </template>
                     </div>
                   </div>
@@ -108,7 +108,7 @@
                 <v-col cols="12" sm="7">
                   <div class="flex-container">
                     <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/email.png')"></v-img></div>
-                    <a class="flex-child-breakable" :href="'mailto:'+shack.email">{{ shack.email }}</a>
+                    <a class="flex-child-breakable" :href="`mailto: ${shack.email}`">{{ shack.email }}</a>
                   </div>
                 </v-col>
               </template>

--- a/src/views/Shacks.vue
+++ b/src/views/Shacks.vue
@@ -103,7 +103,7 @@
                 <v-col cols="12" sm="7">
                   <div class="flex-container">
                     <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/email.png')"></v-img></div>
-                    <div class="flex-child-breakable">{{ shack.email }}</div>
+                    <a class="flex-child-breakable" :href="'mailto:'+shack.email">{{ shack.email }}</a>
                   </div>
                 </v-col>
               </template>

--- a/src/views/Shacks.vue
+++ b/src/views/Shacks.vue
@@ -91,7 +91,13 @@
                 <v-col cols="12" sm="5">
                   <div class="flex-container">
                     <div class="mr-3"><v-img height="25px" width="25px" :src="require('@/assets/icons/phone.png')"></v-img></div>
-                    <div class="flex-child">{{ shack.phones.join(' / ') }} </div>
+                    <div class="flex-child">
+                      <a :href="'tel:'+shack.phones[0]"> {{ shack.phones[0] }}</a>
+                      <template v-if="shack.phones.length > 1">
+                        <a> / </a>
+                        <a :href="'tel:'+shack.phones[1]"> {{ shack.phones[1] }}</a>
+                      </template>
+                    </div>
                   </div>
                 </v-col>
               </template>

--- a/src/views/Shacks.vue
+++ b/src/views/Shacks.vue
@@ -29,6 +29,7 @@
               class="shack-img"
               :height="imageHeight"
               :key="shack.key"
+              :lazy-src="getPreloadImage(images, 0, { height: imageHeight })"
               :src="getImage(images, 0, { height: imageHeight })">
             </v-img>
           </template>
@@ -42,6 +43,7 @@
               <v-carousel-item
                 v-for="(image, i) in images"
                 :key="i"
+                :lazy-src="getPreloadImage(images, i, { height: imageHeight })"
                 :src="getImage(images, i, { height: imageHeight })"
               >
               </v-carousel-item>

--- a/src/views/Shacks.vue
+++ b/src/views/Shacks.vue
@@ -38,6 +38,9 @@
               :height="imageHeight"
               hide-delimiters
               show-arrows-on-hover
+              cycle
+              interval='4000'
+              progress
             >
               <v-carousel-item
                 v-for="(image, i) in images"

--- a/src/views/Shacks.vue
+++ b/src/views/Shacks.vue
@@ -262,10 +262,10 @@ export default {
           { name: 'twitter:title', content: `${this.shack.name} | Mon Petit Sommet` },
           { name: 'twitter:description', content: `${this.shack.name} : informations, équipements, accès, fréquentation` },
         ].concat(this.images.length > 0 ? [
-          { property: 'og:image', content: this.getMetaImageUrl(this.images, 0, { height: 450 }) },
+          { property: 'og:image', content: this.getImage(this.images, 0, { height: 450 }) },
           { property: 'og:image:width', content: '600' },
           { property: 'og:image:height', content: '450' },
-          { name: 'twitter:image', content: this.getMetaImageUrl(this.images, 0, { height: 450 }) },
+          { name: 'twitter:image', content: this.getImage(this.images, 0, { height: 450 }) },
         ] : []),
       };
     }


### PR DESCRIPTION
**1/ Adaptation de la card d'un shack dans la list de la vue massif**
- Ne faire apparaître que "Source" et "Poêle" lorsqu'il y a en a (plus de "Source :oui" ou "Source :non")
- Rendre la partie text (hors photo) de la card cliquable (avec un changement de curseur qui le montre bien)
- Retirer le bouton "Détails"

<img width="810" alt="Capture d’écran 2020-06-22 à 07 53 28" src="https://user-images.githubusercontent.com/64357446/85253050-9a2fbf00-b45d-11ea-86af-2e8312c25f41.png">

**2/ Adaptation du tooltip d'un shack dans la map de la vue massif**
Idem

<img width="261" alt="Capture d’écran 2020-06-22 à 07 53 41" src="https://user-images.githubusercontent.com/64357446/85253039-9439de00-b45d-11ea-93ca-14aab2dbc483.png">
